### PR TITLE
Decouple erwa_protocol module from erwa_router.

### DIFF
--- a/src/erwa_protocol.erl
+++ b/src/erwa_protocol.erl
@@ -23,7 +23,6 @@
 %% @private
 -module(erwa_protocol).
 
--export([forward_messages/2]).
 -export([deserialize/2]).
 -export([serialize/2]).
 -export([to_wamp/1]).
@@ -98,25 +97,6 @@ serialize(Message,raw_json) ->
   Len = byte_size(Enc),
   <<Len:32/unsigned-integer-big,Enc/binary>>.
 
--spec forward_messages(Messages :: list(), Router :: pid() | undefined) -> {ok,Router :: pid() | undefined} | {error,not_found}.
-forward_messages([],Router) ->
-  {ok,Router};
-forward_messages([{hello,Realm,_}|_]=Messages,undefined) ->
-  case erwa_realms:get_router(Realm) of
-    {ok,Pid} ->
-      forward_messages(Messages,Pid);
-    {error,not_found} ->
-      self() ! {erwa,{abort,[{}],no_such_realm}},
-      self() ! {erwa, shutdown},
-      {error,undefined}
-  end;
-forward_messages([Msg|T],Router) when is_pid(Router) ->
-  ok = erwa_router:handle_wamp(Router,Msg),
-  forward_messages(T,Router);
-forward_messages(_,undefined)  ->
-  self() ! {erwa,{abort,[{}],no_such_realm}},
-  self() ! {erwa, shutdown},
-  {error,undefined}.
 
 
 

--- a/src/erwa_tcp_handler.erl
+++ b/src/erwa_tcp_handler.erl
@@ -108,7 +108,7 @@ handle_info({OK,Socket,Data},  #state{ok=OK,enc=Enc,socket=Socket,transport=Tran
   Transport:setopts(Socket, [{active, once}]),
   Buffer = <<Buf/binary, Data/binary>>,
   {Messages,NewBuffer} = erwa_protocol:deserialize(Buffer,Enc),
-  {ok,NewRouter} = erwa_protocol:forward_messages(Messages,Router),
+  {ok,NewRouter} = erwa_router:forward_messages(Messages,Router),
   {noreply, State#state{buffer=NewBuffer,router=NewRouter}};
 handle_info({Closed,Socket}, #state{closed=Closed,socket=Socket}=State) ->
   %erwa_protocol:close(connection_closed,ProtState),

--- a/src/erwa_ws_handler.erl
+++ b/src/erwa_ws_handler.erl
@@ -80,7 +80,7 @@ websocket_terminate(_Reason, _Req, _State) ->
 
 handle_wamp(Data,#state{buffer=Buffer, enc=Enc, router=Router}=State) ->
   {Messages,NewBuffer} = erwa_protocol:deserialize(<<Buffer/binary, Data/binary>>,Enc),
-  {ok,NewRouter} = erwa_protocol:forward_messages(Messages,Router),
+  {ok,NewRouter} = erwa_router:forward_messages(Messages,Router),
   {ok,State#state{router=NewRouter,buffer=NewBuffer}}.
 
 


### PR DESCRIPTION
 Move forward_messages to erwa_protocol. 
It would be right, to have a protocol parser as independent module, so protocol parser can be used for creating custom WAMP routers.
