### PR TITLE
Use cowboy-1.1.x as dependency instead of using master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ERLC_OPTS = +debug_info
 
 
 DEPS = cowboy ranch wamper lager
+dep_cowboy = git https://github.com/ninenines/cowboy.git 1.1.x
 dep_wamper = git https://github.com/bwegh/wamper master
 dep_lager = git https://github.com/basho/lager 3.0.2
 


### PR DESCRIPTION
hello,

I have made this pull-request for use cowboy-1.1.x as dependency instead of using master. The reason of this, the cowboy has major changes on the master branch, most of them are not backward compatible.

You also can refer to this ISSUE:
    https://github.com/ninenines/cowboy/issues/980

I hope you can accept this changes.

thanks,
/Robi